### PR TITLE
Add placeholders for the URLs currently supported by the ASP app

### DIFF
--- a/lib/fstdt_web/controllers/legacy_controller.ex
+++ b/lib/fstdt_web/controllers/legacy_controller.ex
@@ -8,6 +8,11 @@ defmodule FstdtWeb.LegacyController do
   def quote(conn, %{"QID" => legacy_id}) do
     render conn, "todo.html", items: %{legacy_id: legacy_id}
   end
+  def quote(conn, _params) do
+    conn
+    |> put_status(:not_found)
+    |> render(FstdtWeb.ErrorView, :'404')
+  end
 
   def archive(conn, %{"Archive" => legacy_id}) do
     archive_(conn, legacy_id)

--- a/lib/fstdt_web/controllers/legacy_controller.ex
+++ b/lib/fstdt_web/controllers/legacy_controller.ex
@@ -1,0 +1,73 @@
+defmodule FstdtWeb.LegacyController do
+  use FstdtWeb, :controller
+
+  def default(conn, _params) do
+    redirect(conn, to: page_path(conn, :index))
+  end
+
+  def quote(conn, %{"QID" => legacy_id}) do
+    render conn, "todo.html", items: %{legacy_id: legacy_id}
+  end
+
+  def archive(conn, %{"Archive" => legacy_id}) do
+    archive_(conn, legacy_id)
+  end
+  def archive(conn, _params) do
+    archive_(conn, "1")
+  end
+
+  def archive_(conn, legacy_id) do
+    render conn, "todo.html", items: %{legacy_id: legacy_id}
+  end
+
+  def random_quotes(conn, %{"Archive" => legacy_id}) do
+    random_quotes_(conn, legacy_id)
+  end
+  def random_quotes(conn, _params) do
+    random_quotes_(conn, "1")
+  end
+
+  def random_quotes_(conn, legacy_id) do
+    render conn, "todo.html", items: %{legacy_id: legacy_id}
+  end
+
+  def latest_comments(conn, %{"Archive" => legacy_id}) do
+    latest_comments_(conn, legacy_id)
+  end
+  def latest_comments(conn, _params) do
+    latest_comments_(conn, "1")
+  end
+
+  def latest_comments_(conn, legacy_id) do
+    render conn, "todo.html", items: %{legacy_id: legacy_id}
+  end
+
+  def top(conn, %{"Archive" => legacy_id}) do
+    top_(conn, legacy_id)
+  end
+  def top(conn, _params) do
+    top_(conn, "1")
+  end
+
+  def top_(conn, legacy_id) do
+    render conn, "todo.html", items: %{legacy_id: legacy_id}
+  end
+
+  def search(conn, params) do
+    criteria = params
+    |> Enum.flat_map(fn
+      {"Archive", legacy_id} -> [{:archive_legacy_id, legacy_id}]
+      {"Fundie", name} -> [{:quote_fundie_by_name, name}]
+      {"Quote", keywords} -> [{:quote_by_keywords, keywords}]
+      {"Board", name} -> [{:quote_board_by_name, name}]
+      {"Author", name} -> [{:comment_author_by_name, name}]
+      {"Comment", keywords} -> [{:comment_by_keywords, keywords}]
+      _ -> []
+    end)
+    |> case do
+      [] -> %{search: :top_level}
+      criteria -> Map.new(criteria)
+    end
+    render conn, "todo.html", items: criteria
+  end
+end

--- a/lib/fstdt_web/controllers/legacy_controller.ex
+++ b/lib/fstdt_web/controllers/legacy_controller.ex
@@ -5,6 +5,10 @@ defmodule FstdtWeb.LegacyController do
     redirect(conn, to: page_path(conn, :index))
   end
 
+  def faq(conn, _params) do
+    render conn, "todo.html", items: %{page: :faq}
+  end
+
   def quote(conn, %{"QID" => legacy_id}) do
     render conn, "todo.html", items: %{legacy_id: legacy_id}
   end

--- a/lib/fstdt_web/controllers/legacy_controller.ex
+++ b/lib/fstdt_web/controllers/legacy_controller.ex
@@ -9,6 +9,10 @@ defmodule FstdtWeb.LegacyController do
     render conn, "todo.html", items: %{page: :faq}
   end
 
+  def pub_admin(conn, _params) do
+    render conn, "todo.html", items: %{page: :pub_admin}
+  end
+
   def quote(conn, %{"QID" => legacy_id}) do
     render conn, "todo.html", items: %{legacy_id: legacy_id}
   end

--- a/lib/fstdt_web/router.ex
+++ b/lib/fstdt_web/router.ex
@@ -32,6 +32,7 @@ defmodule FstdtWeb.Router do
     get "/Top250.aspx", LegacyController, :top
     get "/Top100.aspx", LegacyController, :top
     get "/Search.aspx", LegacyController, :search
+    get "/FAQ.aspx", LegacyController, :faq
   end
 
   # Other scopes may use custom stacks.

--- a/lib/fstdt_web/router.ex
+++ b/lib/fstdt_web/router.ex
@@ -14,9 +14,24 @@ defmodule FstdtWeb.Router do
   end
 
   scope "/", FstdtWeb do
-    pipe_through :browser # Use the default browser stack
+    pipe_through :browser
 
     get "/", PageController, :index
+  end
+
+  # FSTDT is linked to. A lot. We are *not* going to break those old links.
+  # Luckily, we don't have to; Phoenix has no problem with URLs that happen to end in .aspx.
+  scope "/", FstdtWeb do
+    pipe_through :browser
+
+    get "/Default.aspx", LegacyController, :default
+    get "/QuoteArchives.aspx", LegacyController, :quote
+    get "/ArchiveListing.aspx", LegacyController, :archive
+    get "/RandomQuotes.aspx", LegacyController, :random_quotes
+    get "/LatestComments.aspx", LegacyController, :latest_comments
+    get "/Top250.aspx", LegacyController, :top
+    get "/Top100.aspx", LegacyController, :top
+    get "/Search.aspx", LegacyController, :search
   end
 
   # Other scopes may use custom stacks.

--- a/lib/fstdt_web/router.ex
+++ b/lib/fstdt_web/router.ex
@@ -33,6 +33,7 @@ defmodule FstdtWeb.Router do
     get "/Top100.aspx", LegacyController, :top
     get "/Search.aspx", LegacyController, :search
     get "/FAQ.aspx", LegacyController, :faq
+    get "/PubAdmin.aspx", LegacyController, :pub_admin
   end
 
   # Other scopes may use custom stacks.

--- a/lib/fstdt_web/templates/legacy/todo.html.eex
+++ b/lib/fstdt_web/templates/legacy/todo.html.eex
@@ -1,0 +1,7 @@
+<h1>TODO: implement redirect</h1>
+<dl>
+  <%= for {key, value} <- @items do %>
+    <dt><%= key %></dt>
+    <dd><%= value %></dd>
+  <% end %>
+</dl>

--- a/lib/fstdt_web/views/error_view.ex
+++ b/lib/fstdt_web/views/error_view.ex
@@ -1,6 +1,10 @@
 defmodule FstdtWeb.ErrorView do
   use FstdtWeb, :view
 
+  def render("400.html", _assigns) do
+    "Invalid request"
+  end
+
   def render("404.html", _assigns) do
     "Page not found"
   end

--- a/lib/fstdt_web/views/legacy_view.ex
+++ b/lib/fstdt_web/views/legacy_view.ex
@@ -1,0 +1,3 @@
+defmodule FstdtWeb.LegacyView do
+  use FstdtWeb, :view
+end


### PR DESCRIPTION
* No attempt has been made to redirect sub-pages of PubAdmin, since those should never be linked externally anyway. A top-level redirect is added to help with bookmarks.
* No attempt has been made to handle pagification, since any link to "page 2" is useless anyway. Use permalinks, people!
  * Permalinks for comments don't exist. Sorry. We'll add it in the new version, promise!
* Most of these are placeholders, except `/Default.aspx`, which is obviously correct.